### PR TITLE
Dockerfile Updates and CI

### DIFF
--- a/.github/.workflows/deploy_beta.yml
+++ b/.github/.workflows/deploy_beta.yml
@@ -1,0 +1,19 @@
+name: Deploy the Beta MYR Docker Image
+
+on:
+  repository_dispatch:
+    types: [update_dev]
+
+jobs:
+  deploy_prod:
+    runs-on: ubuntu-latest
+    container:
+      image: docker
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into Quay
+        run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
+      - name: Build the docker image
+        run: docker build -t quay.io/umlecg/myr -f Dockerfile.dev .
+      - name: Deploy the docker image
+        run: docker push quay.io/umlecg/myr:dev

--- a/.github/.workflows/deploy_prod.yml
+++ b/.github/.workflows/deploy_prod.yml
@@ -1,0 +1,19 @@
+name: Deploy the Production MYR Docker Image
+
+on:
+  repository_dispatch:
+    types: [update_master]
+
+jobs:
+  deploy_prod:
+    runs-on: ubuntu-latest
+    container:
+      image: docker
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into Quay
+        run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
+      - name: Build the docker image
+        run: docker build -t quay.io/umlecg/myr -f Dockerfile .
+      - name: Deploy the docker image
+        run: docker push quay.io/umlecg/myr:master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/toshibhtr/ecg-myr-frontend:master AS frontend
-FROM quay.io/toshibhtr/ecg-myr-admin:master AS admin
+FROM quay.io/umlecg/myr-frontend:master AS frontend
+FROM quay.io/umlecg/myr-admin:master AS admin
 
-FROM quay.io/toshibhtr/ecg-myr-backend:master
+FROM quay.io/umlecg/myr-backend:master
 
 ENV MONGO_CONN_STR="mongodb://localhost:27017/ecg-myr"
 ENV GOOGLE_OAUTH2_CLIENTID="Needs to be defined"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
-FROM quay.io/toshibhtr/ecg-myr-frontend:dev AS frontend
-FROM quay.io/toshibhtr/ecg-myr-admin:dev AS admin
+FROM quay.io/umlecg/myr-backend:dev AS frontend
+FROM quay.io/umlecg/myr-admin:dev AS admin
 
-FROM quay.io/toshibhtr/ecg-myr-backend:dev
+FROM quay.io/umlecg/myr-backend:dev
 
 ENV MONGO_CONN_STR="mongodb://localhost:27017/ecg-myr"
 ENV GOOGLE_OAUTH2_CLIENTID="Needs to be defined"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM quay.io/umlecg/myr-backend:dev AS frontend
+FROM quay.io/umlecg/myr-frontend:dev AS frontend
 FROM quay.io/umlecg/myr-admin:dev AS admin
 
 FROM quay.io/umlecg/myr-backend:dev


### PR DESCRIPTION
Adds GitHub CI to trigger a build when it receives a [repository dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows), since this repo should not be updated that much.

Updated dockerfiles to use `umlecg` Quay images instead of my personal ones.